### PR TITLE
The issue related to Slider below Best Deal Section is fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,8 @@
         </div>
       </div>
     </section>
-    <section class="philosophy-img-pop-up">
+    <section class="philosophy-img-pop-up pb-5 pt-5">
+      <div class="border border-2 border-danger rounded-4 border-opacity-50 p-3">
       <a href="./ProductsPage/LinkedHTMLs/philosophy-index.html" target="_blank"><div id="carouselExampleSlidesOnly" class="carousel slide d-none d-md-block" data-bs-ride="carousel"
         data-interval="2000">
         <div class="carousel-inner">
@@ -303,6 +304,7 @@
             <h4 class="d-block fs-48 position-absolute bottom-0 w-100 text-center py-5 mb-0 text-light bg-dark bg-opacity-50 rounded-4">Read Philosophy books here.</h4>
           </div>
       </div></a>
+    </div>
     </section>
     <section class="Philosophy">
       <div class="row shadow border border-2 border-danger rounded-4 border-opacity-50 p-3">


### PR DESCRIPTION
The issue related to the slider section which held below the Deals Section is now fixed by adding border to it. So now it looks separate section.

fix: #55 

![image](https://github.com/Karamraj/BookTown/assets/106877248/f8946e52-5731-4d88-bf3e-4a8f9175eca1)
