### PR TITLE
The issue related to redirecting to mdbootstrap instead of BookTown

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@
             <!-- Copyright -->
             <div class="p-3">
               © 2023 Copyright:
-              <a class="text-white" href="https://mdbootstrap.com/"
+              <a class="text-white" href="index.html"
                  >BookTown.com</a
                 >
             </div>


### PR DESCRIPTION
Now if we click on BookTown.com then it redirects to itself instead of mdbootstrap site.

fix: #42 