### PR TITLE
On Carousel Items Edge Shadows gets cut hotfix

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,6 +111,9 @@ h2::after {
   min-height: 32.5rem;
   text-align: center;
   overflow: hidden;
+  /* below fixes side shadows of book item got cut */
+  padding-left: 2rem; 
+  padding-right: 2rem;
 }
 
 .carousel .thumb-wrapper {


### PR DESCRIPTION
Closes #83 



![image](https://github.com/Karamraj/BookTown/assets/73716444/c080eb99-8962-445f-8a7a-691f55f73719)
these shadows are now showing.