### PR TITLE
CSS: center Add to cart icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -144,8 +144,9 @@ h2::after {
 }
 .addToCart-btn{
   position: absolute;
-  bottom: 20px;
-  left: 40px;
+  left: 0;
+  right: 0;
+  margin: auto;
 }
 .carousel .thumb-wrapper {
   height: 580px;


### PR DESCRIPTION
Add to cart is positioned in right side which doesn't look good, instead we should make it center.

Before
<img width="950" alt="image" src="https://github.com/Karamraj/BookTown/assets/58323485/9e47debd-c44b-4a01-a131-8b1a4097a536">

After
<img width="762" alt="image" src="https://github.com/Karamraj/BookTown/assets/58323485/6958c0a7-3630-4268-a1d4-071334b2b3f3">

Please add hacktober fest label